### PR TITLE
remove final permutedims() in binary_einsum

### DIFF
--- a/ext/MuscleDaggerExt/binary_einsum.jl
+++ b/ext/MuscleDaggerExt/binary_einsum.jl
@@ -2,7 +2,7 @@ using Muscle
 using Dagger: Dagger, ArrayOp, Context, ArrayDomain, EagerThunk, DArray
 using LinearAlgebra
 
-function Muscle.binary_einsum(::Muscle.BackendDagger, inds_c, a, b)
+function Muscle.binary_einsum(::Muscle.BackendDagger, inds_c, a, b; kwargs...)
     op = BinaryEinsum(inds_c, a, b)
     darray = Dagger._to_darray(op)
     return Tensor(darray, inds_c)

--- a/ext/MuscleOMEinsumExt.jl
+++ b/ext/MuscleOMEinsumExt.jl
@@ -37,7 +37,7 @@ function Muscle.unary_einsum!(::BackendOMEinsum, y, x)
     return y
 end
 
-function Muscle.binary_einsum(::Muscle.BackendOMEinsum, inds_c, a, b)
+function Muscle.binary_einsum(::Muscle.BackendOMEinsum, inds_c, a, b; kwargs...)
     size_dict = Dict{Index,Int}()
     for (ind, ind_size) in Iterators.flatten([inds(a) .=> size(a), inds(b) .=> size(b)])
         size_dict[ind] = ind_size

--- a/ext/MuscleReactantExt.jl
+++ b/ext/MuscleReactantExt.jl
@@ -79,7 +79,7 @@ function Muscle.unary_einsum(
 end
 
 Base.@nospecializeinfer @noinline function Muscle.binary_einsum(
-    ::BackendReactant, inds_c, @nospecialize(a::Tensor{TracedRNumber{Ta}}), @nospecialize(b::Tensor{TracedRNumber{Tb}}; kwargs...)
+    ::BackendReactant, inds_c, @nospecialize(a::Tensor{TracedRNumber{Ta}}), @nospecialize(b::Tensor{TracedRNumber{Tb}}); kwargs...
 ) where {Ta,Tb}
     out = inds_c
     dims = setdiff(inds(a) ∩ inds(b), out)

--- a/ext/MuscleReactantExt.jl
+++ b/ext/MuscleReactantExt.jl
@@ -79,7 +79,7 @@ function Muscle.unary_einsum(
 end
 
 Base.@nospecializeinfer @noinline function Muscle.binary_einsum(
-    ::BackendReactant, inds_c, @nospecialize(a::Tensor{TracedRNumber{Ta}}), @nospecialize(b::Tensor{TracedRNumber{Tb}})
+    ::BackendReactant, inds_c, @nospecialize(a::Tensor{TracedRNumber{Ta}}), @nospecialize(b::Tensor{TracedRNumber{Tb}}; kwargs...)
 ) where {Ta,Tb}
     out = inds_c
     dims = setdiff(inds(a) ∩ inds(b), out)

--- a/ext/MuscleStridedExt.jl
+++ b/ext/MuscleStridedExt.jl
@@ -24,7 +24,7 @@ function Muscle.choose_backend_rule(
     BackendStrided()
 end
 
-function Muscle.binary_einsum(::BackendStrided, inds_c, a::Tensor, b::Tensor)
+function Muscle.binary_einsum(::BackendStrided, inds_c, a::Tensor, b::Tensor; kwargs...)
     binary_einsum(
         BackendStrided(),
         inds_c,
@@ -34,7 +34,7 @@ function Muscle.binary_einsum(::BackendStrided, inds_c, a::Tensor, b::Tensor)
 end
 
 function Muscle.binary_einsum(
-    ::BackendStrided, inds_c, a::Tensor{Ta,Na,<:StridedView}, b::Tensor{Tb,Nb,<:StridedView}
+    ::BackendStrided, inds_c, a::Tensor{Ta,Na,<:StridedView}, b::Tensor{Tb,Nb,<:StridedView}; kwargs...
 ) where {Ta,Tb,Na,Nb}
     inds_contract = inds(a) ∩ inds(b)
     inds_left = setdiff(inds(a), inds_contract)

--- a/src/Operations/binary_einsum.jl
+++ b/src/Operations/binary_einsum.jl
@@ -92,7 +92,7 @@ function binary_einsum(::BackendBase, inds_c, a::Tensor, b::Tensor)
     c_mat = a_mat * b_mat
 
     c = Tensor(reshape(c_mat, sizes_left..., sizes_right...), [inds_left; inds_right])
-    return permutedims(c, inds_c)
+    return c
 end
 
 function binary_einsum!(::BackendBase, c::Tensor, a::Tensor, b::Tensor)

--- a/src/Operations/binary_einsum.jl
+++ b/src/Operations/binary_einsum.jl
@@ -50,17 +50,12 @@ function binary_einsum(a::Tensor, b::Tensor; dims=(∩(inds(a), inds(b))), out=n
     #     backend = choose_backend(binary_einsum, data_a, data_b)
     # end
 
-    c = if backend == Muscle.BackendBase()
-            binary_einsum(backend, inds_c, a, b; reorder_inds)
-        else
-            binary_einsum(backend, inds_c, a, b)
-        end
-
-    return c
+    return binary_einsum(backend, inds_c, a, b; reorder_inds)
+       
 
 end
 
-function binary_einsum(::Backend, inds_c, a, b)
+function binary_einsum(::Backend, inds_c, a, b; kwargs...)
     throw(ArgumentError("`binary_einsum` not implemented or not loaded for backend $(typeof(a))"))
 end
 

--- a/src/Operations/binary_einsum.jl
+++ b/src/Operations/binary_einsum.jl
@@ -41,7 +41,7 @@ function binary_einsum(a::Tensor, b::Tensor; dims=(∩(inds(a), inds(b))), out=n
         reorder_inds = true
         out
     end
-
+ 
     backend = choose_backend(binary_einsum, parent(a), parent(b))
     # if ismissing(backend)
     #     @warn "No backend found for binary_einsum(::$(typeof(a)), ::$(typeof(b))), so unwrapping data"
@@ -50,7 +50,14 @@ function binary_einsum(a::Tensor, b::Tensor; dims=(∩(inds(a), inds(b))), out=n
     #     backend = choose_backend(binary_einsum, data_a, data_b)
     # end
 
-    return binary_einsum(backend, inds_c, a, b; reorder_inds)
+    c = if backend == Muscle.BackendBase()
+            binary_einsum(backend, inds_c, a, b; reorder_inds)
+        else
+            binary_einsum(backend, inds_c, a, b)
+        end
+
+    return c
+
 end
 
 function binary_einsum(::Backend, inds_c, a, b)


### PR DESCRIPTION
maybe I don't fully understand the logic in all those index sets in binary_einsum, but if we can get rid of the final permutedims() that would give a significant speedup. The tests hopefully will help see if I'm wrong
